### PR TITLE
fix: Issue #14 - ログ記録時のキャッシュ無効化が動作しない問題

### DIFF
--- a/src/__tests__/integration/activityLoggingIntegration.test.ts
+++ b/src/__tests__/integration/activityLoggingIntegration.test.ts
@@ -169,16 +169,29 @@ describe('活動記録システム統合テスト', () => {
     });
 
     test('ログ記録時にキャッシュが無効化される', async () => {
-      const mockMessage = new MockMessage('新しい活動ログ');
+      const userId = 'test-user-123';
+      const messageContent = '新しい活動ログ';
       
       // キャッシュサービスのinvalidateCacheメソッドをスパイ
       const cacheService = (integration as any).analysisCacheService;
       const invalidateSpy = jest.spyOn(cacheService, 'invalidateCache').mockResolvedValue(true);
       
-      const handleMessage = (integration as any).handleMessage.bind(integration);
-      const result = await handleMessage(mockMessage as unknown as Message);
+      // TodoHandlerの活動ログ作成メソッドを直接呼び出す（ボタン押下をシミュレート）
+      const todoHandler = (integration as any).todoHandler;
       
-      expect(result).toBe(true);
+      // createActivityLogFromMessageを直接テストする
+      const mockInteraction = {
+        update: jest.fn().mockResolvedValue(undefined)
+      };
+      
+      // createActivityLogFromMessageはprivateメソッドなので、リフレクションで呼び出し
+      await (todoHandler as any).createActivityLogFromMessage(
+        mockInteraction,
+        messageContent,
+        userId,
+        'Asia/Tokyo'
+      );
+      
       expect(invalidateSpy).toHaveBeenCalled();
       
       invalidateSpy.mockRestore();

--- a/src/integration/activityLoggingIntegration.ts
+++ b/src/integration/activityLoggingIntegration.ts
@@ -149,7 +149,8 @@ export class ActivityLoggingIntegration {
         this.repository, // IMessageClassificationRepository  
         this.geminiService,
         this.messageClassificationService,
-        this.activityLogService // 活動ログサービスを注入
+        this.activityLogService, // 活動ログサービスを注入
+        this.analysisCacheService // キャッシュ無効化のため追加
       );
       
       // プロファイル機能ハンドラーの初期化


### PR DESCRIPTION
## Summary
Issue #14: ログ記録時のキャッシュ無効化が動作しない問題を修正

## Problem
- TODOメッセージ分類で活動ログが作成された際に、キャッシュの無効化が実行されない
- テスト「ログ記録時にキャッシュが無効化される」が失敗していた

## Root Cause
TodoCommandHandlerの`createActivityLogFromMessage`メソッドで活動ログを作成する際に、キャッシュ無効化処理が実装されていなかった。

## Solution
### 1. TodoCommandHandlerにAnalysisCacheServiceを注入
```typescript
constructor(
  // 既存の依存関係...
  private analysisCacheService?: AnalysisCacheService // 追加
) { }
```

### 2. createActivityLogFromMessageでキャッシュ無効化を実装
```typescript
if (this.activityLogService) {
  const log = await this.activityLogService.recordActivity(userId, message, timezone);
  
  // キャッシュを無効化（新しいログが追加されたため）
  if (this.analysisCacheService) {
    await this.analysisCacheService.invalidateCache(userId, log.businessDate);
  }
}
```

### 3. ActivityLoggingIntegrationで依存性注入
```typescript
this.todoHandler = new TodoCommandHandler(
  // 既存の依存関係...
  this.analysisCacheService // キャッシュサービスを注入
);
```

### 4. テストを現在のアーキテクチャに合わせて修正
- AI分類優先方式に対応
- createActivityLogFromMessageメソッドを直接テスト
- ボタン押下のシミュレーション

## Technical Details
- **アーキテクチャ**: AI分類優先方式（メッセージ → 分類 → ボタン選択 → 活動ログ作成）
- **キャッシュ戦略**: 活動ログ作成時の即座なキャッシュ無効化
- **テスト戦略**: プライベートメソッドの直接テスト（リフレクション使用）

## Test Results
```
✓ ログ記録時にキャッシュが無効化される (7161 ms)
```

## Files Changed
- `src/handlers/todoCommandHandler.ts`
- `src/integration/activityLoggingIntegration.ts`
- `src/__tests__/integration/activityLoggingIntegration.test.ts`

Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)