### PR TITLE
fix: Issue #13 - テスト環境でTARGET_USER_ID設定値が空文字列になる問題

### DIFF
--- a/src/integration/activityLoggingIntegration.ts
+++ b/src/integration/activityLoggingIntegration.ts
@@ -890,7 +890,7 @@ export function createDefaultConfig(databasePath: string, geminiApiKey: string):
     defaultTimezone: 'Asia/Tokyo',
     enableAutoAnalysis: true,
     cacheValidityMinutes: 60,
-    targetUserId: '' // マルチユーザー対応により削除（レガシー設定）
+    targetUserId: process.env.TARGET_USER_ID || '' // テスト環境での動作を保証
   };
 }
 


### PR DESCRIPTION
## Summary
Issue #13: テスト環境でTARGET_USER_ID設定値が空文字列になる問題を修正

## Problem
- テストケース「設定値を確認する」で期待値 `"770478489203507241"` に対して実際は `""` が返される
- `integration.getConfig().targetUserId` が空文字列となり、テストが失敗していた

## Root Cause
`createDefaultConfig`関数で`targetUserId`が固定で空文字列に設定されており、環境変数`TARGET_USER_ID`を参照していなかった。

```typescript
// 問題のあるコード
targetUserId: '' // マルチユーザー対応により削除（レガシー設定）
```

テストの`beforeAll`では環境変数を設定していたが、`createDefaultConfig`がそれを無視していた。

## Solution
`createDefaultConfig`関数で環境変数`TARGET_USER_ID`を参照するように修正。

```typescript
// 修正後
targetUserId: process.env.TARGET_USER_ID || '' // テスト環境での動作を保証
```

## Technical Details
- **対象ファイル**: `src/integration/activityLoggingIntegration.ts`
- **修正箇所**: `createDefaultConfig`関数の`targetUserId`設定
- **下位互換性**: 環境変数が未設定の場合は空文字列となり、既存動作を維持

## Test Results
```
✓ 設定値を確認する (1 ms)
```

テストが正常に通過し、環境変数で設定した値が正しく取得されることを確認。

## Impact
- **テスト環境**: 設定値検証テストが正常に動作
- **本番環境**: 環境変数が未設定の場合は従来通り空文字列（マルチユーザー対応）
- **開発環境**: 必要に応じて環境変数で設定可能

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)